### PR TITLE
ci: molecule-plugins, dockerpy/urllib3 workaround

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install molecule[docker] ansible-lint flake8 testinfra ansible
+          pip install molecule molecule-plugins docker ansible-lint flake8 testinfra ansible
           mkdir -p $HOME/.ansible/roles && ln -s $GITHUB_WORKSPACE/$ANSIBLE_ROLE $HOME/.ansible/roles/
       - name: Environment
         run: |

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install molecule molecule-plugins docker ansible-lint flake8 testinfra ansible
+          # Workaround for https://github.com/docker/docker-py/issues/3113
+          pip install "urllib3<2"
           mkdir -p $HOME/.ansible/roles && ln -s $GITHUB_WORKSPACE/$ANSIBLE_ROLE $HOME/.ansible/roles/
       - name: Environment
         run: |


### PR DESCRIPTION
* move to current molecule-plugins module
* Workaround for https://github.com/docker/docker-py/issues/3113