### PR TITLE
ci(lint): exclude .github/workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,5 +48,5 @@ jobs:
         if: ${{ always() }}
       - name: ansible-lint
         run: |
-          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE && ansible-lint
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE && ansible-lint --exclude .github/workflows
         if: ${{ always() }}


### PR DESCRIPTION
to address ansible-lint errors